### PR TITLE
Parse confirm

### DIFF
--- a/main_view.py
+++ b/main_view.py
@@ -149,16 +149,11 @@ class main_view(Gtk.Grid):
     def search_current_file(self, editor_buffer: GPS.EditorBuffer, parse_rule: lal.GrammarRule, search_query: str):
         """Searches the currently opened file for the provided search query."""
         filepath = editor_buffer.file().path
-
-        console = GPS.Console("Find AST")
-
         # search for matches in current file
         self.execute_search(filepath, search_query, parse_rule)
 
     def search_current_project(self, editor_buffer: GPS.EditorBuffer, parse_rule: lal.GrammarRule, search_query: str):
         """Searches the entire project for the provided search query."""
-        console = GPS.Console("Find AST")
-
         current_project = editor_buffer.file().project()
 
         source_dirs: list[str] = current_project.source_dirs()

--- a/searchresult.py
+++ b/searchresult.py
@@ -1,6 +1,7 @@
 import libadalang as lal # type: ignore
 from typing import Optional, List
 from location import Location
+import GPS
 
 class SearchResult:
     """Class used for searching a text in a file and storing its location.
@@ -18,19 +19,21 @@ class SearchResult:
     fragment_tree: lal.AnalysisUnit
     last_location: str
     case_insensitive: Optional[bool]
-    found: bool
 
-    def __init__(self, filename: str, fragment: str, rule: Optional[lal.GrammarRule] = lal.default_grammar_rule,
-                 case_insensitive: Optional[bool] = False):
+    def __init__(self, filename: str, fragment: str, rule: lal.GrammarRule = lal.default_grammar_rule, case_insensitive: Optional[bool] = False):
         """Constructor method
         """
         self.locations = []
-        self.file_tree = self.analyze_file(filename)
-        self.fragment_tree = self.analyze_fragment(fragment, rule)
         self.last_location = ""
         self.case_insensitive = case_insensitive
+        self.analyze_file(filename)
+        if not self.analyze_fragment(fragment, rule):
+            choice = GPS.MDI.combo_selection_dialog("Try other rules?", "Rule " + str(rule) + " did not parse your search query, should we try other parse rules?", ["Yes", "No"])
+            if choice == "Yes":
+                self.analyze_fragment_try_rules(fragment)
+            else:
+                parse_failure()
         self.is_subtree(self.file_tree.root, self.fragment_tree.root)
-        self.found = bool(self.locations)
 
     def are_identical(self, root1, root2) -> bool:
         """
@@ -73,26 +76,30 @@ class SearchResult:
                 self.locations.append(self.parse_sloc(self.last_location))
         return False
 
-    def analyze_fragment(self, fragment: str, rule: Optional[lal.GrammarRule]) -> lal.AnalysisUnit:
+    def analyze_fragment(self, fragment:str, rule: lal.GrammarRule) -> bool:
+        context = lal.AnalysisContext()
+        unit = context.get_from_buffer("", fragment, rule=getattr(lal.GrammarRule, rule))
+        if not unit.diagnostics:
+            self.fragment_tree = unit
+            return True
+        return False
+
+    def analyze_fragment_try_rules(self, fragment: str):
         """
         Creates a tree from text fragment
 
         :return: An analysis unit containing the tree
         """
-        rules = lal.GrammarRule._c_to_py[::-1]
-        rules.insert(0, rules.pop(rules.index(str(rule))))
+        rules = lal.GrammarRule._c_to_py
         for idx, rule in enumerate(rules):
             if idx != 0:
                 print(rules[idx - 1], "failed, retrying with", rule)
-            context = lal.AnalysisContext()
-            unit = context.get_from_buffer("", fragment, rule=getattr(lal.GrammarRule, rule))
-            if not unit.diagnostics:
-                return unit
-        for d in unit.diagnostics:
-            print(d)
-        raise ValueError
-    
-    def analyze_file(self, filename: str) -> lal.AnalysisUnit:
+            if self.analyze_fragment(fragment, rule):
+                print("Succeeded with", rule)
+                return
+        parse_failure()
+
+    def analyze_file(self, filename: str):
         """
         Creates a tree from ada file
 
@@ -101,7 +108,8 @@ class SearchResult:
         context = lal.AnalysisContext()
         unit = context.get_from_file(filename)
         if not unit.diagnostics:
-            return unit
+            self.file_tree = unit
+            return
         for d in unit.diagnostics:
             print(d)
         raise ValueError
@@ -115,6 +123,10 @@ class SearchResult:
         [line1, pos1], [line2, pos2] = range_[0].split(":"), range_[1].split(":")
         return Location(int(line1), int(line2), int(pos1), int(pos2))
 
+def parse_failure():
+    GPS.MDI.dialog("Search query couldn't be parsed :(")
+    raise ValueError
+    
 
 def text_comparison(text1, text2, case_insensitive):
     return text1 == text2 if not case_insensitive else text1.lower() == text2.lower()


### PR DESCRIPTION
This branch adds the following functionality:
When the user tries to search for something, but the selected parse rule does not parse the search query, a pop-up is shown informing the user and asking whether they want the application to try other parse rules. If they select yes, the application tries other rules, otherwise the application stops trying to parse and raises a ValueError.

This branch also includes some reformatting of the SearchResult class:
typing all variables, 
removing some unnecessary ones, 
splitting functions that do too much into smaller functions