### PR TITLE
Parse exceptions and parse failure fix

### DIFF
--- a/api.py
+++ b/api.py
@@ -10,6 +10,7 @@ import libadalang as lal  # type: ignore
 import searchresult as sr
 import replacer as rep
 from location import Location
+import exceptions
 
 
 def findall_file(
@@ -28,10 +29,13 @@ def findall_file(
     :return: A list of locations where the file matches the search query
     """
     try:
-        pattern = _analyze_string(search_query, parse_rule)
         operand = _analyze_file(filepath)
     except ValueError as error:
-        raise error
+        raise exceptions.OperandParseError from error
+    try:
+        pattern = _analyze_string(search_query, parse_rule)
+    except ValueError as error:
+        raise exceptions.PatternParseException from error
     return _execute_search(pattern.root, operand.root, case_insensitive)
 
 
@@ -98,10 +102,13 @@ def findall_string(
     :return: A list of locations where the string matches the search query
     """
     try:
-        pattern = _analyze_string(search_query, search_query_parse_rule)
         operand = _analyze_string(to_search, to_search_parse_rule)
     except ValueError as error:
-        raise error
+        raise exceptions.OperandParseError from error
+    try:
+        pattern = _analyze_string(search_query, search_query_parse_rule)
+    except ValueError as error:
+        raise exceptions.PatternParseException from error
     return _execute_search(pattern.root, operand.root, case_insensitive)
 
 

--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,6 @@
+"""Module defining some useful custom exceptions."""
+class OperandParseError(Exception):
+    """Exception raised when an operand (string or file) could not be parsed to an AST"""
+
+class PatternParseException(Exception):
+    """Exception raised when a search pattern could not be parsed to an AST"""

--- a/main_view.py
+++ b/main_view.py
@@ -8,6 +8,7 @@ import libadalang as lal  # type: ignore
 import GPS
 import api
 from location import Location
+import exceptions
 
 from gi.repository import Gtk, GLib, Gdk, GObject  # type: ignore
 
@@ -221,7 +222,7 @@ class main_view(Gtk.Grid):
                 parse_rule,
                 self.case_insensitive_button.get_active(),
             )
-        except ValueError:
+        except exceptions.PatternParseException:
             choice = GPS.MDI.combo_selection_dialog(
                 "Try other rules?",
                 "Rule "
@@ -238,6 +239,9 @@ class main_view(Gtk.Grid):
                 )
             else:
                 return
+        except exceptions.OperandParseError:
+            GPS.MDI.dialog("The file could not be parsed. Please check for any errors and fix them.")
+            return
         for location in locations:
             self.locations.append((filepath, location))
 


### PR DESCRIPTION
Added two exceptions that specify whether it was the pattern that failed to parse or the operand (string or file).
Using these more specific exceptions, we can now distinguish between parse failures in either case, allowing us to tell when the provided file or string can't be parsed and correctly inform the user.